### PR TITLE
Support `money_without_trailing_zeros` filter

### DIFF
--- a/jquery.currencies.js
+++ b/jquery.currencies.js
@@ -585,18 +585,9 @@ Currency.convertAll = function(oldCurrency, newCurrency, selector, format) {
     }
     else {
       // Converting to Y for the first time? Let's get to it!
-      var cents = 0.0;
       var oldFormat = Currency.moneyFormats[oldCurrency][format || Currency.format] || '{{amount}}';
       var newFormat = Currency.moneyFormats[newCurrency][format || Currency.format] || '{{amount}}';
-      if (oldFormat.indexOf('amount_no_decimals') !== -1) {
-        cents = Currency.convert(parseInt(jQuery(this).html().replace(/[^0-9]/g, ''), 10)*100, oldCurrency, newCurrency);
-      }
-      else if (oldCurrency === 'JOD' || oldCurrency == 'KWD' || oldCurrency == 'BHD') {
-        cents = Currency.convert(parseInt(jQuery(this).html().replace(/[^0-9]/g, ''), 10)/10, oldCurrency, newCurrency);
-      }
-      else { 
-        cents = Currency.convert(parseInt(jQuery(this).html().replace(/[^0-9]/g, ''), 10), oldCurrency, newCurrency);
-      }
+      var cents = Currency.convert(parseFloat(jQuery(this).html().replace(/^[^0-9]+|[^0-9.]/g, ''), 10) * 100, oldCurrency, newCurrency);
       var newFormattedAmount = Currency.formatMoney(cents, newFormat);
       jQuery(this).html(newFormattedAmount);
       jQuery(this).attr('data-currency-'+newCurrency, newFormattedAmount);


### PR DESCRIPTION
Previously, price parsing depends on the `amount`/`amount_no_decimals` config. It assumes that there will be trailing zeros if the format is `amount`. It can not handle scenarios where money format is `amount` while `money_without_trailing_zeros` filter is used in rendering.

After the patch, parsing has no assumption on the format. It takes care of `.`s in prices and try to parse them as floats.

The first part (`^[^0-9]+`) of the regex `/^[^0-9]+|[^0-9.]/g` handle format prefixes with dots, e.g. `Dhs. {{amount}} AED`, `Rs. {{amount}}`. The second part of the regex get the number part of the price.

It can handle formats like `$99.90 USD`, `$99 USD`, `Dhs. 99.90 AED`, `Dhs. 99 AED`, and three decimal formats `99.900 BHD`.